### PR TITLE
Check for the existence of specific functions instead of just checking

### DIFF
--- a/classes/Kohana/Image/GD.php
+++ b/classes/Kohana/Image/GD.php
@@ -10,13 +10,13 @@
  */
 class Kohana_Image_GD extends Image {
 
-	// Is GD bundled or separate?
-	protected static $_bundled;
+	// Which GD functions are available?
+	protected static $_available_functions = array();
 
 	/**
-	 * Checks if GD is enabled and bundled. Bundled GD is required for some
-	 * methods to work. Exceptions will be thrown from those methods when GD is
-	 * not bundled.
+	 * Checks if GD is enabled and verify that key methods exist, some of which require GD to
+	 * be bundled with PHP.  Exceptions will be thrown from those methods when GD is not
+	 * bundled.
 	 *
 	 * @return  boolean
 	 */
@@ -27,19 +27,10 @@ class Kohana_Image_GD extends Image {
 			throw new Kohana_Exception('GD is either not installed or not enabled, check your configuration');
 		}
 
-		if (defined('GD_BUNDLED'))
-		{
-			// Get the version via a constant, available in PHP 5.
-			Image_GD::$_bundled = GD_BUNDLED;
-		}
-		else
-		{
-			// Get the version information
-			$info = gd_info();
-
-			// Extract the bundled status
-			Image_GD::$_bundled = (bool) preg_match('/\bbundled\b/i', $info['GD Version']);
-		}
+                foreach (array('imagerotate', 'imageconvolution', 'imagefilter', 'imagelayereffect') as $func)
+                {
+                        Image_GD::$_available_functions[$func] = function_exists($func);
+                }
 
 		if (defined('GD_VERSION'))
 		{
@@ -246,7 +237,7 @@ class Kohana_Image_GD extends Image {
 	 */
 	protected function _do_rotate($degrees)
 	{
-		if ( ! Image_GD::$_bundled)
+		if ( ! isset(Image_GD::$_available_functions['imagerotate']) )
 		{
 			throw new Kohana_Exception('This method requires :function, which is only available in the bundled version of GD',
 				array(':function' => 'imagerotate'));
@@ -328,7 +319,7 @@ class Kohana_Image_GD extends Image {
 	 */
 	protected function _do_sharpen($amount)
 	{
-		if ( ! Image_GD::$_bundled)
+		if ( ! isset(Image_GD::$_available_functions['imageconvolution']) )
 		{
 			throw new Kohana_Exception('This method requires :function, which is only available in the bundled version of GD',
 				array(':function' => 'imageconvolution'));
@@ -367,7 +358,7 @@ class Kohana_Image_GD extends Image {
 	 */
 	protected function _do_reflection($height, $opacity, $fade_in)
 	{
-		if ( ! Image_GD::$_bundled)
+		if ( ! isset(Image_GD::$_available_functions['imagefilter']) )
 		{
 			throw new Kohana_Exception('This method requires :function, which is only available in the bundled version of GD',
 				array(':function' => 'imagefilter'));
@@ -448,7 +439,7 @@ class Kohana_Image_GD extends Image {
 	 */
 	protected function _do_watermark(Image $watermark, $offset_x, $offset_y, $opacity)
 	{
-		if ( ! Image_GD::$_bundled)
+		if ( ! isset(Image_GD::$_available_functions['imagelayereffect']) )
 		{
 			throw new Kohana_Exception('This method requires :function, which is only available in the bundled version of GD',
 				array(':function' => 'imagelayereffect'));


### PR DESCRIPTION
to see if GD is bundled.  This provides granular support in more cases.
Resolves http://dev.kohanaframework.org/issues/4735
