### PR TITLE
Add colorspace_rgb(), resolution(), and strip() methods (for imagick)

### DIFF
--- a/classes/Kohana/Image.php
+++ b/classes/Kohana/Image.php
@@ -585,6 +585,46 @@ abstract class Kohana_Image {
 	}
 
 	/**
+	 * Set image colorspace to RGB
+	 *
+	 * @return   $this
+	 * @uses     Image::_colorspace_rgb
+	 */
+	public function colorspace_rgb()
+	{
+		$this->_colorspace_rgb();
+
+		return $this;
+	}
+
+	/**
+	 * Set image resolution and resample it
+	 *
+	 * @param   int   $dpi  Image resolution (DPI)
+	 * @return  $this
+	 * @uses    Image::_do_resolution
+	 */
+	public function resolution($dpi = 72)
+	{
+		$this->_do_resolution($dpi);
+
+		return $this;
+	}
+
+	/**
+	 * Strip image of all profiles and comments
+	 *
+	 * @return  $this
+	 * @uses    Image::_do_strip
+	 */
+	public function strip()
+	{
+		$this->_do_strip();
+
+		return $this;
+	}
+
+	/**
 	 * Save the image. If the filename is omitted, the original image will
 	 * be overwritten.
 	 *
@@ -757,5 +797,27 @@ abstract class Kohana_Image {
 	 * @return  string
 	 */
 	abstract protected function _do_render($type, $quality);
+
+	/**
+	 * Converts image from CMYK to RGB (if necessary)
+	 *
+	 * @return  $this
+	 * @uses    Image::_do_colorspace_to_rgb
+	 */
+	abstract protected function _colorspace_rgb();
+
+	/**
+	 * Resample image to desired resolution
+	 *
+	 * @return  $this
+	 */
+	abstract protected function _do_resolution($dpi);
+
+	/**
+	 * Strip image of all profiles and comments
+	 *
+	 * @return  $this
+	 */
+	abstract protected function _do_strip();
 
 } // End Image

--- a/classes/Kohana/Image/GD.php
+++ b/classes/Kohana/Image/GD.php
@@ -662,4 +662,19 @@ class Kohana_Image_GD extends Image {
 		return $image;
 	}
 
+	protected function _colorspace_rgb()
+	{
+		return TRUE;
+	}
+
+	protected function _do_resolution($dpi)
+	{
+		return TRUE;
+	}
+
+	protected function _do_strip()
+	{
+		return TRUE;
+	}
+
 } // End Image_GD

--- a/classes/Kohana/Image/Imagick.php
+++ b/classes/Kohana/Image/Imagick.php
@@ -331,4 +331,75 @@ class Kohana_Image_Imagick extends Image {
 
 		return array($format, $type);
 	}
+
+	protected function _colorspace_rgb()
+	{
+		if ($this->im->getColorspace() == Imagick::COLORSPACE_CMYK OR $this->im->getImageColorspace() == Imagick::COLORSPACE_CMYK)
+		{
+			$this->im->negateImage(FALSE);
+			$this->im->setColorspace(Imagick::COLORSPACE_SRGB);
+			$this->im->setImageColorspace(Imagick::COLORSPACE_SRGB);
+		}
+
+		$this->im->profileImage('*', NULL);
+		$this->im->stripImage();
+
+		return $this->im;
+	}
+
+	protected function _do_resolution($dpi)
+	{
+		$resolution = $this->im->getImageResolution();
+
+		if (is_array($dpi))
+		{
+			// Change DPI for each X/Y, let's only accept int
+			if (isset($dpi['x']) AND is_int($dpi['x']) AND isset($dpi['y']) AND is_int($dpi['y']))
+			{
+				// Only change DPI if we need to
+				if ($resolution['x'] == $dpi['x'] AND $resolution['y'] == $dpi['y'])
+				{
+					return $this->im;
+				}
+				else
+				{
+					$this->im->setImageResolution ($dpi['x'], $dpi['y']);
+					$this->im->resampleImage($dpi['x'], $dpi['y'], Imagick::FILTER_UNDEFINED, 0);
+					return $this->im;
+				}
+			}
+			else
+			{
+				// Wrong arguments
+				return $this->im;
+			}
+		}
+		else
+		{
+			if (!is_int($dpi))
+			{
+				return $this->im;
+			}
+
+			// Change DPI equally, but only if we need to
+			if ($resolution['x'] == $dpi AND $resolution['y'] == $dpi)
+			{
+				return $this->im;
+			}
+			else
+			{
+				$this->im->setImageResolution ($dpi, $dpi);
+				$this->im->resampleImage($dpi, $dpi, Imagick::FILTER_UNDEFINED, 0);
+				return $this->im;
+			}
+		}
+	}
+
+	protected function _do_strip()
+	{
+		$this->im->profileImage('*', NULL);
+		$this->im->stripImage();
+		return $this->im;
+	}
+
 } // End Kohana_Image_Imagick


### PR DESCRIPTION
Added 3 methods to the Kohana/Image/Imagick class:

`colorspace_rgb()`
To convert CMYK to RGB

`resolution()`
To change image resolution from 300 DPI (usually uploads) to 72 DPI for web and resample the image (DPI should be `int` or `array` of X/Y DPI).
I've included the option to accept an array with different DPI such as `['x' => 72, 'y' => 96]` if that's your thing ;)

`strip()`
To strip all color profiles and comments from the file (usually another problem with large file sizes)

These have been tested; but I didn't have the time set up proper unit tests for them... :p

Another note; I didn't have the time to implement or even look at the GD driver, and if anything I'd like to work on a GraphicsMagick driver first... So for now I've got them returning TRUE (please don't hurt me :laughing:)

Cheers
