### PR TITLE
Added a configuration option to define default driver for Image module

### DIFF
--- a/classes/Kohana/Image.php
+++ b/classes/Kohana/Image.php
@@ -23,6 +23,7 @@ abstract class Kohana_Image {
 	const VERTICAL   = 0x12;
 
 	/**
+	 * @deprecated - provide an image.default_driver value in your configuration instead
 	 * @var  string  default driver: GD, ImageMagick, etc
 	 */
 	public static $default_driver = 'GD';

--- a/classes/Kohana/Image.php
+++ b/classes/Kohana/Image.php
@@ -44,8 +44,9 @@ abstract class Kohana_Image {
 	{
 		if ($driver === NULL)
 		{
-			// Use the default driver
-			$driver = Image::$default_driver;
+			// Use the driver from configuration file or default one
+			$configured_driver = Kohana::$config->load('image.default_driver');
+			$driver = ($configured_driver) ? $configured_driver : Image::$default_driver;
 		}
 
 		// Set the class name

--- a/config/image.php
+++ b/config/image.php
@@ -1,6 +1,8 @@
 <?php defined('SYSPATH') OR die('No direct script access.');
 
 return array(
-	// Default driver: GD, Imagick, etc
-	'default_driver' => 'Imagick',
+	// Provide the default driver to use - eg a value of Imagick will use Image_Imagick as the driver class
+	// If you set a value for this config key, then the Image::$default_driver static variable that was used
+	// to configure earlier versions will be ignored.
+	'default_driver' => NULL,
 );

--- a/config/image.php
+++ b/config/image.php
@@ -1,0 +1,6 @@
+<?php defined('SYSPATH') OR die('No direct script access.');
+
+return array(
+	// Default driver: GD, Imagick, etc
+	'default_driver' => 'Imagick',
+);

--- a/guide/image/index.md
+++ b/guide/image/index.md
@@ -4,7 +4,24 @@ Kohana 3.x provides a simple yet powerful image manipulation module. The [Image]
 
 ## Drivers
 
-[Image] module ships with [Image_GD] driver which requires `GD` extension enabled in your PHP installation. This is the default driver. Additional drivers can be created by extending the [Image] class.
+[Image] module ships with [Image_GD] driver which requires `GD` extension enabled in your PHP installation, and
+[Image_Imagick] driver which requires the `imagick` PHP extension. Additional drivers can be created by extending 
+the [Image] class.
+
+The [Image_GD] driver is the default. You can change this by providing an `image.default_driver` configuration option
+- for example:
+
+~~~
+// application/config/image.php
+<?php
+return array(
+    'default_driver' => 'Imagick'
+);
+~~~
+
+[!!] Older versions of Kohana allowed you to configure the driver with the `Image::$default_driver` static variable in
+the bootstrap, an extension class, or elsewhere. That variable is now deprecated and will be ignored if you set a 
+config value. 
 
 ## Getting Started
 


### PR DESCRIPTION
This replaces #9 to make the new config option backwards compatible with existing projects. Also rebased onto 3.3/develop so we could see the travis build running.

Closes #9
